### PR TITLE
update 'ws' dependency to version 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "colors": "^1.1.0",
     "moment": "^2.10.3",
     "rethinkdb": "^2.0.0",
-    "ws": "^0.7.2"
+    "ws": "^0.8.0"
   },
   "devDependencies": {
     "babel": "^5.5.6",


### PR DESCRIPTION
needed to compile without error on node v 4.0 and up
