### PR TITLE
Support rethinkdbdash

### DIFF
--- a/src/QueryParser.js
+++ b/src/QueryParser.js
@@ -133,7 +133,9 @@ const parseQuery = (query, queryOptions) => {
   const parseTerm = data => {
     if (isArr(data)) {
       let [termId, args, options] = data;
-      if (!args) args = [];
+      if (args === undefined) {
+        args = [];
+      }
       ensure(data.length <= 3, 'Too many array elements');
       ensure(isArr(args), 'Invalid args type');
       ensure(options === undefined || isObj(options), 'Invalid options type');

--- a/src/QueryParser.js
+++ b/src/QueryParser.js
@@ -132,7 +132,8 @@ const rqToString = (query, initialIndentLevel = 0, spacesPerIndent = 0) => {
 const parseQuery = (query, queryOptions) => {
   const parseTerm = data => {
     if (isArr(data)) {
-      const [termId, args, options] = data;
+      let [termId, args, options] = data;
+      if (!args) args = [];
       ensure(data.length <= 3, 'Too many array elements');
       ensure(isArr(args), 'Invalid args type');
       ensure(options === undefined || isObj(options), 'Invalid options type');

--- a/src/ReqlAstBuilder.js
+++ b/src/ReqlAstBuilder.js
@@ -39,7 +39,8 @@ const buildAstTerm = (termId, args, options) => {
 // protocol. May throw an exception if the term is ill formed.
 const reqlJsonToAst = term => {
   if (isArr(term)) {
-    const [termId, args, options] = term;
+    let [termId, args, options] = term;
+    if (!args) args = [];
     ensure(term.length <= 3, 'Too many array elements');
     ensure(isArr(args), 'Invalid args type');
     ensure(options === undefined || isObj(options), 'Invalid options type');

--- a/src/ReqlAstBuilder.js
+++ b/src/ReqlAstBuilder.js
@@ -40,7 +40,9 @@ const buildAstTerm = (termId, args, options) => {
 const reqlJsonToAst = term => {
   if (isArr(term)) {
     let [termId, args, options] = term;
-    if (!args) args = [];
+    if (args === undefined) {
+      args = [];
+    }
     ensure(term.length <= 3, 'Too many array elements');
     ensure(isArr(args), 'Invalid args type');
     ensure(options === undefined || isObj(options), 'Invalid options type');


### PR DESCRIPTION
`rethinkdbdash` sends `args` as `undefined` instead of an empty array, so `rethinkdb-websocket-server` would throw. This fixes it, making it possible for rethinkdbdash to work as the client connecting to `rethinkdb-websocket-server`.
